### PR TITLE
Change to package.json to call for MacOS usable icon and change to README.md to show how to compile :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,15 @@ Give a follow to [Caffeinated](https://www.caffeine.tv/Caffeinated_)
 - Overlapping alerts - a delay has to be set so all alerts play after previous one has finished.
 
 ## For developers
+- Make sure you have electron-builder to compile the app
+- To install electron-builder you have to run the command ```npm  install electron-builder -g```
 ```elm
 git clone https://github.com/thehelvijs/Caffeinated  
 cd app  
 npm install  
-npm start  
+electron-builder -wl
 ```
+- MacOS builds do still need to be made the same way on macos but with ```-m``` instead of ```-wl```
 
 ## Acknowledgments
 

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "dist": "electron-builder"
   },
   "build": {
+    "icon": "media/app_icon.icns",
     "appId": "casterlabs.caffeinated",
     "dmg": {
       "contents": [


### PR DESCRIPTION
Edited the package.json to call for a icon on the MacOS compile. Also edited the README.md to tell how to compile to get the icon file working on MacOS. Can only compile MacOS version on MacOS.